### PR TITLE
mise à jour via npm update

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -11,11 +11,11 @@
     "start": "moleculer-runner --env --instances=max services"
   },
   "dependencies": {
-    "@semapps/ldp": "0.1.25",
-    "@semapps/triplestore": "0.1.25",
-    "@semapps/fuseki-admin": "0.1.25",
+    "@semapps/ldp": "^0.1.25",
+    "@semapps/triplestore": "^0.1.25",
+    "@semapps/fuseki-admin": "^0.1.25",
 {{#sparqlEndpoint}}
-    "@semapps/sparql-endpoint": "0.1.23",
+    "@semapps/sparql-endpoint": "^0.1.23",
 {{/sparqlEndpoint}}
     "dotenv": "^8.2.0",
     "moleculer": "^0.14.4",


### PR DESCRIPTION
le ^ permet de specifier une version minimum mais update les package en cas de ```npm update``` pour résoudre https://github.com/assemblee-virtuelle/semapps/issues/490
```
C:\Users\Smag\Documents\dev\semapps>npm update
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN semapps@1.0.0 No repository field.
npm WARN semapps@1.0.0 No license field.

+ @semapps/sparql-endpoint@0.1.41
+ @semapps/triplestore@0.1.41
+ @semapps/ldp@0.1.41
+ @semapps/fuseki-admin@0.1.41
added 4 packages from 1 contributor, removed 5 packages, updated 31 packages and audited 306 packages in 14.946s

18 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```